### PR TITLE
[STDLIB] Add wrappers for vsnprint, vsprint

### DIFF
--- a/api/scm_wifi.c
+++ b/api/scm_wifi.c
@@ -828,7 +828,6 @@ int scm_wifi_sta_set_config(scm_wifi_assoc_request *req, void *fast_config)
 fail:
 	SCM_ERR_LOG(SCM_API_TAG,"%s Invalid Input: %s\n", __func__, err);
 	return ret;
-
 }
 
 int scm_wifi_sta_connect(void)


### PR DESCRIPTION
New features:

Changes:

- Add __wrap_vsnprint and __wrap_vsprint to support an external software, e.g., Matter,to be able to use platform-provided corresponding functions.

Fixes:

Issues: