### PR TITLE
[API] Connect AP even if the auth mode is not clear

### DIFF
--- a/api/include/scm_wifi.h
+++ b/api/include/scm_wifi.h
@@ -499,6 +499,8 @@ int scm_wifi_sta_set_config(scm_wifi_assoc_request *req, void *fast_config);
 
 int scm_wifi_sta_connect(void);
 
+int scm_wifi_sta_connect_advance(void);
+
 int scm_wifi_sta_disconnect(void);
 
 int scm_wifi_sta_disconnect_event(uint8_t enable);


### PR DESCRIPTION
New features:

Changes:
- Get the correct auth mode of the certain AP from scan list and reconnect

Fixes:

Issues: