### PR TITLE
[MCUBOOT] Add proper C linkage declaration to flash_map_backend.h

### DIFF
--- a/lib/scm_mcuboot/mcuboot/boot/wise/include/flash_map_backend/flash_map_backend.h
+++ b/lib/scm_mcuboot/mcuboot/boot/wise/include/flash_map_backend/flash_map_backend.h
@@ -19,6 +19,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -407,5 +411,9 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id);
  ****************************************************************************/
 
 int flash_area_id_from_image_offset(uint32_t offset);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLASH_MAP_BACKEND_H_ */

--- a/lib/scm_mcuboot/mcuboot/boot/wise/include/sysflash/sysflash.h
+++ b/lib/scm_mcuboot/mcuboot/boot/wise/include/sysflash/sysflash.h
@@ -13,6 +13,10 @@
 #ifndef _SYSFLASH_H_
 #define _SYSFLASH_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -29,4 +33,7 @@
                                          SECONDARY_ID)
 #define FLASH_AREA_IMAGE_SCRATCH       SCRATCH_ID
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _SYSFLASH_H_ */


### PR DESCRIPTION
New features:

Changes:
- Add proper C linkage declaration to flash_map_backend.h so that external C++ files can access the right functions

Fixes:

Issues: