### PR TITLE
[Ayla] Use sysytem partition for factory data

### DIFF
--- a/api/scm_wifi.c
+++ b/api/scm_wifi.c
@@ -879,12 +879,12 @@ int scm_wifi_sta_connect_advance(void)
 			if (strcmp((char *)config.sta.ssid, pst_results[loop].ssid) != 0)
 				continue;
 
-		memcpy(req.ssid, config.sta.ssid, strlen((char *)config.sta.ssid));
-		memcpy(req.key, config.sta.password, strlen((char *)config.sta.password));
+			memcpy(req.ssid, config.sta.ssid, strlen((char *)config.sta.ssid));
+			memcpy(req.key, config.sta.password, strlen((char *)config.sta.password));
 			req.auth = pst_results[loop].auth;
-		req.pairwise = SCM_WIFI_PAIRWISE_AES;
-		scm_wifi_sta_set_config(&req, NULL);
-		ret = scm_wifi_sta_connect();
+			req.pairwise = SCM_WIFI_PAIRWISE_AES;
+			scm_wifi_sta_set_config(&req, NULL);
+			ret = scm_wifi_sta_connect();
 		}
 	}
 	free(pst_results);

--- a/app/ayla/Kconfig
+++ b/app/ayla/Kconfig
@@ -17,4 +17,12 @@ config AYLA_LOCAL_CONTROL_SUPPORT
 	bool "Ayla Local Control support"
 	default y
 
+config AYLA_SYSTEM_PARTITION_ADDR
+    hex "Ayla System Partition Address"
+    default 0x80014000
+
+config AYLA_SYSTEM_PARTITION_SIZE
+    int "Ayla System Partition Size"
+    default 4096
+
 endmenu

--- a/app/ayla/components/al/wise/al_persist.c
+++ b/app/ayla/components/al/wise/al_persist.c
@@ -16,11 +16,11 @@
 #include <string.h>
 #include <errno.h>
 
-
 #include <ayla/utypes.h>
 #include <ayla/assert.h>
 #include <ayla/log.h>
 #include <al/al_persist.h>
+#include <al/al_os_mem.h>
 
 #define PERSIST_PATH_ROOT 		"/ayla"
 #define PERSIST_PATH_STARTUP	"startup"
@@ -31,6 +31,118 @@
 			)
 #define PERSIST_PATH_MAX_LEN	64
 
+#define AYLA_FACTORY_INFO_PART_ADDR  CONFIG_AYLA_SYSTEM_PARTITION_ADDR
+#define AYLA_FACTORY_INFO_PART_SIZE  CONFIG_AYLA_SYSTEM_PARTITION_SIZE
+
+struct al_persist_factory_info {
+    uint8_t dsn[20];            /* factory/id/dev_id */
+    uint8_t dsn_pubkey[400];    /* factory/id/key */
+    uint8_t oem[20];            /* factory/oem/oem */
+    uint8_t oem_model[24];      /* factory/oem/model */
+    uint8_t oem_key[256];       /* factory/oem/key */
+    uint8_t serial[32];
+} __packed;
+
+/* XXX: Alas! Can't include <hal/spi-flash.h> because of type conflicts. */
+extern int flash_erase(off_t addr, size_t size, unsigned how);
+extern int flash_write(off_t addr, void *buf, size_t size);
+extern int flash_read(off_t addr, void *buf, size_t size);
+
+static int al_persist_read_system_partition(enum al_persist_section section,
+        const char *name, struct al_persist_factory_info **info,
+        uint8_t **data, int *sz)
+{
+    if (section != AL_PERSIST_FACTORY) {
+        return -1;
+    }
+
+    if (strcmp(name, "id/dev_id")
+            && strcmp(name, "id/key")
+            && strcmp(name, "oem/oem")
+            && strcmp(name, "oem/model")
+            && strcmp(name, "oem/key")) {
+        return -1;
+    }
+
+    *info = (struct al_persist_factory_info *)al_os_mem_alloc(sizeof(**info));
+    if (*info == NULL) {
+		log_put(LOG_ERR "al_os_mem_alloc failed\n");
+        return -1;
+    }
+
+    if (flash_read(AYLA_FACTORY_INFO_PART_ADDR, *info, sizeof(**info)) < 0) {
+		log_put(LOG_ERR "flash_read failed\n");
+        al_os_mem_free(*info);
+        return -1;
+    }
+
+    if (!strcmp(name, "id/dev_id")) {
+        *data = (*info)->dsn;
+        *sz = sizeof((*info)->dsn);
+    } else if (!strcmp(name, "id/key")) {
+        *data = (*info)->dsn_pubkey;
+        *sz = sizeof((*info)->dsn_pubkey);
+    } else if (!strcmp(name, "oem/oem")) {
+        *data = (*info)->oem;
+        *sz = sizeof((*info)->oem);
+    } else if (!strcmp(name, "oem/model")) {
+        *data = (*info)->oem_model;
+        *sz = sizeof((*info)->oem_model);
+    } else if (!strcmp(name, "oem/key")) {
+        *data = (*info)->oem_key;
+        *sz = sizeof((*info)->oem_key);
+    }
+
+    return 0;
+}
+
+static int al_persist_data_read_from_system_partition(enum al_persist_section section,
+		const char *name, void *buf, size_t len)
+{
+    struct al_persist_factory_info *info;
+    uint8_t *data;
+    int sz;
+
+    if (al_persist_read_system_partition(section, name, &info, &data, &sz) < 0) {
+        return -1;
+    }
+
+    sz = (sz > len) ? len : sz;
+    memcpy(buf, data, sz);
+    al_os_mem_free(info);
+
+    return sz;
+}
+
+static int al_persist_data_write_to_system_partition(enum al_persist_section section,
+		const char *name, const void *buf, size_t len)
+{
+    struct al_persist_factory_info *info;
+    uint8_t *data;
+    int sz;
+
+    if (al_persist_read_system_partition(section, name, &info, &data, &sz) < 0) {
+        return -1;
+    }
+
+    memset(data, 0, sz);
+    sz = (sz > len) ? len : sz;
+    memcpy(data, buf, sz);
+
+    if (flash_erase(AYLA_FACTORY_INFO_PART_ADDR, AYLA_FACTORY_INFO_PART_SIZE, 0) < 0) {
+        al_os_mem_free(info);
+        return -1;
+    }
+
+    if (flash_write(AYLA_FACTORY_INFO_PART_ADDR, info, sizeof(*info)) < 0) {
+        al_os_mem_free(info);
+        return -1;
+    }
+
+    al_os_mem_free(info);
+    return 0;
+}
+
 enum al_err al_persist_data_write(enum al_persist_section section,
 		const char *name, const void *buf, size_t len)
 {
@@ -39,6 +151,10 @@ enum al_err al_persist_data_write(enum al_persist_section section,
 	int ret;
 
 	log_put(LOG_DEBUG "persist write: %d/%s\n", section, name);
+
+    if (al_persist_data_write_to_system_partition(section, name, buf, len) == 0) {
+        return 0;
+    }
 
 	sprintf(path, "%s/%s/%s",
 		PERSIST_PATH_ROOT,
@@ -74,6 +190,10 @@ ssize_t al_persist_data_read(enum al_persist_section section,
 	int ret;
 
 	log_put(LOG_DEBUG "persist read: %d/%s\n", section, name);
+
+    if ((ret = al_persist_data_read_from_system_partition(section, name, buf, len)) > 0) {
+        return ret;
+    }
 
 	sprintf(path, "%s/%s/%s",
 		PERSIST_PATH_ROOT,


### PR DESCRIPTION
New features:

Changes:

- Use a dedicated system partion on the SPI flash for saving factory configuration.

Fixes:

Issues: